### PR TITLE
Optimize Gemini API usage with thinking_budget parameter

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,16 +26,20 @@ app.add_middleware(
 
 embeddings = HuggingFaceEmbeddings(model_name=config.EMBEDDING_MODEL)
 
+# Chat endpoint: thinking disabled for faster, conversational responses
 llm = ChatGoogleGenerativeAI(
-    model="models/gemini-2.0-flash",
+    model="models/gemini-2.5-flash",
     google_api_key=config.GOOGLE_API_KEY,
-    temperature=0.7
+    temperature=0.7,
+    thinking_budget=0  # Disable thinking for chat
 )
 
+# Algorithm & analysis endpoints: thinking enabled for deeper reasoning
 reasoning_llm = ChatGoogleGenerativeAI(
     model="models/gemini-2.5-flash",
     google_api_key=config.GOOGLE_API_KEY,
-    temperature=0.7
+    temperature=0.7,
+    thinking_budget=-1  # Dynamic thinking (model decides)
 )
 
 # request schemas


### PR DESCRIPTION
## Summary
This PR optimizes the Gemini API integration by using the `thinking_budget` parameter to control reasoning depth across different endpoints, replacing the previous approach of using two different models.

## Changes
- **Unified Model**: Use `gemini-2.5-flash` for all endpoints instead of mixing `gemini-2.0-flash` and `gemini-2.5-flash`
- **Chat endpoint**: `thinking_budget=0` for faster, conversational responses
- **Analysis endpoints** (`/projectcode`, `/analysis`, `/updatecode`): `thinking_budget=-1` for dynamic deep reasoning


## Testing
All endpoints tested and verified

## References
- LangChain documentation on Gemini thinking control: https://python.langchain.com/docs/integrations/chat/google_generative_ai/#gemini-2-5-models-thinking_budget