### PR TITLE
feat: add sliding window with conversation summarization

### DIFF
--- a/main.py
+++ b/main.py
@@ -168,7 +168,7 @@ async def chat(request: QueryRequest):
     }
 
     # Check threshold and summarize if needed
-    summarize_result = check_and_summarize(raw_messages, conversation_summary, summarized_up_to)
+    summarize_result = summarize_messages(raw_messages, conversation_summary, summarized_up_to)
     if summarize_result:
         response_data["conversation_summary"] = summarize_result["conversation_summary"]
         response_data["summarized_up_to"] = summarize_result["summarized_up_to"]

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-from typing import List, Dict
+from typing import List, Dict, Optional
 from fastapi.middleware.cors import CORSMiddleware
 
 from langchain_core.messages import SystemMessage, HumanMessage, AIMessage, BaseMessage
@@ -9,7 +9,7 @@ from langchain_huggingface import HuggingFaceEmbeddings
 
 import config
 import json
-from utils.prompts import mentor_config, general_instructions, generateAlgorithmPrompt, updateAlgorithmPrompt, generateAnalysis
+from utils.prompts import mentor_config, general_instructions, generateAlgorithmPrompt, updateAlgorithmPrompt, generateAnalysis, generateConversationSummary
 from utils.parser import convert_music_blocks
 from utils.blocks import findBlockInfo
 from retriever import getContext
@@ -23,8 +23,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-embeddings = HuggingFaceEmbeddings(model_name=config.EMBEDDING_MODEL)
 
 # Chat endpoint: thinking disabled for faster, conversational responses
 llm = ChatGoogleGenerativeAI(
@@ -42,12 +40,17 @@ reasoning_llm = ChatGoogleGenerativeAI(
     thinking_budget=-1  # Dynamic thinking (model decides)
 )
 
+SUMMARIZE_THRESHOLD = 16  # 8 pairs of user+AI messages
+KEEP_RECENT = 6  # 3 pairs sent in full next call
+
 # request schemas
 class QueryRequest(BaseModel):
     query: str
     messages: List[Dict[str, str]]
     mentor: str
     algorithm: str
+    conversation_summary: Optional[str] = None  
+    summarized_up_to: int = 0  
 
 class CodeRequest(BaseModel):
     code: str
@@ -117,12 +120,17 @@ async def update_projectcode(request: CodeUpdateRequest):
     except Exception as e:
         return {"error": str(e)}
 
+
+
+
 @app.post("/chat/")
 async def chat(request: QueryRequest):
     query = request.query.strip()
-    raw_messages = request.messages
+    raw_messages = request.messages  
     mentor = request.mentor.lower()
     algorithm = request.algorithm
+    conversation_summary = request.conversation_summary
+    summarized_up_to = request.summarized_up_to
 
     if not query:
         return {"error": "Empty query"}
@@ -137,20 +145,35 @@ async def chat(request: QueryRequest):
     else:
         messages.insert(0, SystemMessage(content=system_prompt))
 
-    # Add relevant context from RAG
+    if conversation_summary:
+        messages.insert(1, AIMessage(
+            content=f"[Summary of earlier conversation]: {conversation_summary}"
+        ))
+
     rag_context = getContext(query)
     if rag_context:
-        messages.insert(1, HumanMessage(content=f"Relevant context:\n{rag_context}"))
+        enhanced_query = f"[Relevant context: {rag_context}]\n\n{query}"
+    else:
+        enhanced_query = query
 
-    messages.append(HumanMessage(content=query))
+    messages.append(HumanMessage(content=enhanced_query))
 
     try:
-        result = llm.invoke(messages) #invoking llm with messages, not a single query
-        return {
-            "response": result.content
-        }
+        result = llm.invoke(messages)
     except Exception as e:
         return {"error": str(e)}
+
+    response_data = {
+        "response": result.content,
+    }
+
+    # Check threshold and summarize if needed
+    summarize_result = check_and_summarize(raw_messages, conversation_summary, summarized_up_to)
+    if summarize_result:
+        response_data["conversation_summary"] = summarize_result["conversation_summary"]
+        response_data["summarized_up_to"] = summarize_result["summarized_up_to"]
+
+    return response_data
     
 @app.post("/analysis/")
 async def analysis(request: AnalysisRequest):
@@ -169,15 +192,41 @@ async def analysis(request: AnalysisRequest):
     except Exception as e:
         return {"error": str(e)}
 
+def summarize_messages(raw_messages,conversation_summary,summarized_up_to) :
+    
+    if len(raw_messages) <= SUMMARIZE_THRESHOLD:
+        return None
+
+    try:
+        messages_to_summarize = raw_messages[:-KEEP_RECENT]
+
+        formatted = "\n".join(
+            f"{m.get('role', 'unknown').upper()}: {m.get('content', '')}"
+            for m in messages_to_summarize
+        )
+
+        summary_result = llm.invoke(
+            generateConversationSummary(conversation_summary, formatted)
+        )
+
+        new_summarized_up_to = summarized_up_to + len(messages_to_summarize)
+
+        return {
+            "conversation_summary": summary_result.content,
+            "summarized_up_to": new_summarized_up_to
+        }
+    except Exception as e:
+        return None
+
 def convert_messages(raw_messages: List[Dict[str, str]]) -> List[BaseMessage]:
     converted = []
     for msg in raw_messages:
-        role = msg["role"]
-        content = msg["content"]
+        role = msg.get("role", "")
+        content = msg.get("content", "")
         if role == "system":
             converted.append(SystemMessage(content=content))
         elif role == "user":
             converted.append(HumanMessage(content=content))
-        elif role == "meta" or "code" or "music":
+        elif role in ("meta", "code", "music"):
             converted.append(AIMessage(content=content))
     return converted

--- a/utils/prompts.py
+++ b/utils/prompts.py
@@ -141,6 +141,27 @@ def updateAlgorithmPrompt(oldFlowchart, newFlowchart, blockInfo):
     - `response`: string containing only the description of changes
     """
 
+def generateConversationSummary(old_summary, messages_to_summarize):
+    return f"""
+    You are a conversation summarizer. Your job is to create a concise summary of a chat conversation
+    between a student and their mentor(s) on the MusicBlocks platform.
+
+    This summary will be used as context for future messages, so capture:
+    - Key topics discussed (what the student built, what blocks/techniques they used)
+    - Questions asked by mentors and the student's answers
+    - Any decisions, challenges, or insights mentioned
+    - Where the conversation left off (what was being discussed last)
+
+    Be factual and concise. Do NOT analyze or give recommendations — just summarize what happened.
+    Keep it under 200 words.
+
+    {f"Previous summary (of even older messages):{chr(10)}{old_summary}" if old_summary else "No previous summary."}
+
+    New messages to summarize:
+    {messages_to_summarize}
+    """
+
+
 def generateAnalysis(old_summary, conversation):
     analysis_prompt = f"""
     You are an expert reflective coach analyzing a learner's journey. Your task is to deeply analyze these summaries to identify the following:


### PR DESCRIPTION
### Problem

Currently, the **entire chat history** is sent to the Gemini API on every `/chat/` request. As conversations grow longer, this causes:

- **Increased token usage and cost** — every message is re-processed on each call
- **Slower response times** — larger payloads and longer context for the LLM
- **Risk of hitting context window limits** — Gemini has token limits that long conversations can exceed

### Solution

Implement a **sliding window with threshold based summarization** across both the backend (FastAPI) and frontend (MusicBlocks reflection widget).

#### How it works

1. The frontend tracks `conversationSummary` and `summarizedUpTo` (index of last summarized message)
2. On each request, only **unsummarized messages** (`chatHistory.slice(summarizedUpTo)`) are sent to the backend
3. When unsummarized messages exceed `SUMMARIZE_THRESHOLD` (16 messages / ~8 user-AI pairs):
   - The backend summarizes all but the most recent `KEEP_RECENT` (6) messages into a concise conversation summary
   - The summary + new `summarized_up_to` index are returned to the frontend
   - The frontend stores them for the next request
4. On subsequent calls, the summary is injected as context so the AI retains awareness of the full conversation

### Changes

#### Backend (`musicblocks_reflection_fastapi`)

**main.py**
- Added `conversation_summary` (Optional[str]) and `summarized_up_to` (int) fields to `QueryRequest`
- Added `check_and_summarize()` function — checks threshold, summarizes older messages, returns updated summary + index
- `/chat/` endpoint now injects conversation summary as context and appends RAG context inline to the user query (not as a separate message)
- Configuration: `SUMMARIZE_THRESHOLD = 16`, `KEEP_RECENT = 6`

**prompts.py**
- Added `generateConversationSummary(old_summary, messages_to_summarize)` — produces a factual conversation recap (not a learning analysis) under 200 words

#### Frontend (`musicblocks`)

**reflection.js**
- Added `conversationSummary` and `summarizedUpTo` state to constructor
- `generateBotReply()` now sends only `chatHistory.slice(this.summarizedUpTo)` instead of the full history
- Includes `conversation_summary` and `summarized_up_to` in the request body
- Updates local state when backend returns a new summary

