### PR TITLE
Fix logic flaw in convert_messages role evaluation

### DIFF
--- a/main.py
+++ b/main.py
@@ -178,6 +178,6 @@ def convert_messages(raw_messages: List[Dict[str, str]]) -> List[BaseMessage]:
             converted.append(SystemMessage(content=content))
         elif role == "user":
             converted.append(HumanMessage(content=content))
-        elif role == "meta" or "code" or "music":
+        elif role in ["meta", "code", "music", "assistant"]:
             converted.append(AIMessage(content=content))
     return converted


### PR DESCRIPTION
Hi Diwangshu! I am interested in proposing a project for the GSoC 2026 'AI Reflection' idea.

While exploring the codebase, I noticed that the `if/elif` handling for message roles in main.py had a logic evaluation bug. 
Python evaluates `role == "meta" or "code" or "music"` as continuously Truthy since `"code"` and `"music"` strings evaluate to True. 

I updated it to use standard list inclusion: `role in ["meta", "code", "music", "assistant"]` so it properly filters out unexpected roles.
